### PR TITLE
fix: Limit paths exposed in the ingresses to those needed to send telemetry

### DIFF
--- a/.github/workflows/eu1-deploy.yaml
+++ b/.github/workflows/eu1-deploy.yaml
@@ -51,8 +51,12 @@ jobs:
             --set ingress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"="${{ secrets.EU1_ACM_ARN }}" \
             --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="${{ secrets.EU1_DNS_NAME }}" \
             --set ingress.hosts[0].host="${{ secrets.EU1_DNS_NAME }}" \
+            --set ingress.hosts[1].host="${{ secrets.EU1_DNS_NAME }}" \
+            --set ingress.hosts[2].host="${{ secrets.EU1_DNS_NAME }}" \
             --set grpcIngress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"="${{ secrets.EU1_ACM_ARN }}" \
             --set grpcIngress.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="${{ secrets.EU1_DNS_NAME }}" \
             --set grpcIngress.hosts[0].host="${{ secrets.EU1_DNS_NAME }}" \
+            --set grpcIngress.hosts[1].host="${{ secrets.EU1_DNS_NAME }}" \
+            --set grpcIngress.hosts[2].host="${{ secrets.EU1_DNS_NAME }}" \
             --set config.Network.HoneycombAPI="https://api.eu1.honeycomb.io" \
             --wait --debug

--- a/.github/workflows/refinery-deploy.yaml
+++ b/.github/workflows/refinery-deploy.yaml
@@ -53,7 +53,11 @@ jobs:
             --set ingress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"="${{ secrets.US1_ACM_ARN }}" \
             --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="${{ secrets.US1_DNS_NAME }}" \
             --set ingress.hosts[0].host="${{ secrets.US1_DNS_NAME }}" \
+            --set ingress.hosts[1].host="${{ secrets.US1_DNS_NAME }}" \
+            --set ingress.hosts[2].host="${{ secrets.US1_DNS_NAME }}" \
             --set grpcIngress.annotations."alb\.ingress\.kubernetes\.io/certificate-arn"="${{ secrets.US1_ACM_ARN }}" \
             --set grpcIngress.annotations."external-dns\.alpha\.kubernetes\.io/hostname"="${{ secrets.US1_DNS_NAME }}" \
             --set grpcIngress.hosts[0].host="${{ secrets.US1_DNS_NAME }}" \
+            --set grpcIngress.hosts[1].host="${{ secrets.US1_DNS_NAME }}" \
+            --set grpcIngress.hosts[2].host="${{ secrets.US1_DNS_NAME }}" \
             --wait --debug

--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -225,7 +225,11 @@ ingress:
     kubernetes.io/ingress.class: alb
   hosts:
     - host: _replaceme_
-      path: /
+      path: /1/
+    - host: _replaceme_
+      path: /v1/
+    - host: _replaceme_
+      path: /query/
   labels: {}
 
 grpcIngress:
@@ -251,5 +255,9 @@ grpcIngress:
     kubernetes.io/ingress.class: alb
   hosts:
     - host: _replaceme_
-      path: /
+      path: /1/
+    - host: _replaceme_
+      path: /v1/
+    - host: _replaceme_
+      path: /query/
   labels: {}


### PR DESCRIPTION
## Short description of the changes

The original build of this opened all endpoints that Refinery has to the internet through the Load Balancer.  This doesn't expose a lot of vulnerabilities to the internet, but there are things that the internet really just doesn't need access to.

I've updated the refinery-values file to limit the paths opened to the ingresses. Just the paths for the Honeycomb events and batch API, and then for the OTLP traffic sent to Honeycomb.  I've also left the `/query/` endpoint available, though we can discuss if we should close this off as well.

## How to verify that this has the expected result

After deployment, the AWS load balancer rules should have limited paths available to accept traffic on. 