### PR TITLE
fix(ingress): Update ingress annotations to drop invalid headers on AWS ALB

### DIFF
--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -220,6 +220,7 @@ ingress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
     alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
     external-dns.alpha.kubernetes.io/hostname: _replaceme_
     kubernetes.io/ingress.class: alb
@@ -246,6 +247,7 @@ grpcIngress:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/load-balancer-attributes: routing.http.drop_invalid_header_fields.enabled=true
     alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
     external-dns.alpha.kubernetes.io/hostname: _replaceme_
     kubernetes.io/ingress.class: alb


### PR DESCRIPTION
## Which problem is this PR solving?

- Should resolve this [Pentest Finding](https://app.asana.com/0/365940753298424/1208096654572919/f)

## Short description of the changes

Adds a load balancer attribute annotation in the ingress that will tell AWS to drop invalid header fields on the ALB created.

## How to verify that this has the expected result

After deploy, verify manually in AWS that the load balancer has selected to drop invalid HTTP headers