### PR TITLE
fix default peerbuffersize value

### DIFF
--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -11,7 +11,7 @@ customvals:
   - &incomingQueueSize 150_000
   - &peerQueueSize 150_000
   - &upstreamBufferSize 50_000
-  - &peerBufferSize 50_000
+  - &peerBufferSize 1_000_000
   - &spanLimit 1_000
   - &sendDelay 10s
   - &traceTimeout 60s

--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -151,7 +151,6 @@ config:
   Collection:
     AvailableMemory: *memory
     MaxMemoryPercentage: 75
-    CacheCapacity: *cacheCapacity
     IncomingQueueSize: *incomingQueueSize
     PeerQueueSize: *peerQueueSize
   BufferSizes:

--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -7,7 +7,6 @@ customvals:
   # Sizing example for an m7g.large (2 vCPU, 8 GiB memory) EC2 instance
   - &memory 5Gi # lowered to allow more memory for daemonsets and other pods monitoring the nodes
   - &cpu 1250m # lowered to allow more memory for daemonsets and other pods monitoring the nodes
-  - &cacheCapacity 55_000
   - &incomingQueueSize 150_000
   - &peerQueueSize 150_000
   - &upstreamBufferSize 50_000
@@ -18,12 +17,13 @@ customvals:
 # Sizing example for an r7g.4xlarge (16 vCPU, 128 GiB memory) EC2 instance
 # - &memory 120Gi
 # - &cpu 14
-# - &cacheCapacity      1_000_000
 # - &incomingQueueSize  3_000_000
 # - &peerQueueSize      3_000_000
 # - &upstreamBufferSize 1_000_000
 # - &peerBufferSize     1_000_000
 # - &spanLimit 32_000
+# - &sendDelay 10s
+# - &traceTimeout 60s
 
 ###############################################################################
 ### Rules: How Refinery Processes Traces - See Link Below for More Info     ###


### PR DESCRIPTION
Default [peerbuffersize](https://docs.honeycomb.io/manage-data-volume/sample/honeycomb-refinery/configure/#peerbuffersize) is 100000; updated the config file here