### PR TITLE
update slack recipient for triggers

### DIFF
--- a/.github/workflows/tf-hny-triggers.yaml
+++ b/.github/workflows/tf-hny-triggers.yaml
@@ -14,6 +14,7 @@ env:
   HONEYCOMB_API_KEY: ${{ secrets.REFINERY_HONEYCOMB_API_KEY }}
   KUBE_NAMESPACE: ${{ vars.K8S_NAMESPACE }}
   HONEYCOMB_API_ENDPOINT: ${{ vars.HONEYCOMB_API_ENDPOINT }}
+  TF_VAR_slack_recipient_channel: ${{ secrets.SLACK_RECIPIENT_CHANNEL }}
 
 jobs:
   terraform-download-apply-upload:

--- a/terraform/recipients.tf
+++ b/terraform/recipients.tf
@@ -1,4 +1,3 @@
 resource "honeycombio_slack_recipient" "alerts" {
-  count   = var.create_slack_recipient ? 1 : 0
   channel = var.slack_recipient_channel
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,17 +3,7 @@ variable "refinery_metrics_dataset" {
   default = "refinery-metrics"
 }
 
-variable "create_slack_recipient" {
-  type    = bool
-  default = false
-}
-
 variable "slack_recipient_channel" {
   type    = string
-  default = "#exp-hosted-refinery-for-pocs"
-}
-
-variable "existing_slack_recipient_id" {
-  type    = string
-  default = "C050ZJGP2KW" # Default to the channel ID for #collab-hosted-refinery-for-pocs
+  default = "#collab-hosted-refinery-for-pocs"
 }

--- a/variables.md
+++ b/variables.md
@@ -30,8 +30,9 @@ If looking for the values in the AWS console, please make sure to check the corr
 
 You may find these in your respective Honeycomb.io refinery-as-a-service team (US or EU).
 
-| Name                         | Where to Find Value                                                                                         |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `REFINERY_HONEYCOMB_API_KEY` | Your Honeycomb.io refinery-as-a-service team (US or EU). Must be a key with permissions to create triggers. |
-| `REFINERY_QUERY_AUTH_TOKEN`  | User determined value. `C0ntains.L1ve.B33s` is the default value.                                           |
-| `TF_STATE_PASSHRASE`         | User determined value.                                                                                      |
+| Name                         | Where to Find Value                                                                                            |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `REFINERY_HONEYCOMB_API_KEY` | Your Honeycomb.io refinery-as-a-service team (US or EU). Must be a key with permissions to create triggers.    |
+| `REFINERY_QUERY_AUTH_TOKEN`  | User determined value. `C0ntains.L1ve.B33s` is the default value.                                              |
+| `TF_STATE_PASSHRASE`         | User determined value.                                                                                         |
+| `SLACK_RECIPIENT_CHANNEL`    | `#collab-hosted-refinery-for-pocs` is the default value. This is the channel where notifications will be sent. |


### PR DESCRIPTION
Updated to be more in line with the provider docs (https://registry.terraform.io/providers/honeycombio/honeycombio/latest/docs/resources/slack_recipient) and use the channel name from git secrets