### PR TITLE
fix(raas-poc): update mem req

### DIFF
--- a/refinery-values.yaml
+++ b/refinery-values.yaml
@@ -14,8 +14,8 @@ customvals:
   - &spanLimit 1_000
   - &sendDelay 10s
   - &traceTimeout 60s
-# Sizing example for an r7g.4xlarge (16 vCPU, 128 GiB memory) EC2 instance
-# - &memory 120Gi
+# Sizing example for an r8g.4xlarge (16 vCPU, 128 GiB memory) EC2 instance
+# - &memory 115Gi
 # - &cpu 14
 # - &incomingQueueSize  3_000_000
 # - &peerQueueSize      3_000_000


### PR DESCRIPTION
Memory req needs to be lowered with all the other stuff running in the cluster from 120 --> 115 (lacework, otel collector etc.)